### PR TITLE
Limit gsub replacements

### DIFF
--- a/chrolo/lib.lua
+++ b/chrolo/lib.lua
@@ -353,14 +353,14 @@ function split_at_override_tags(str)
 			--put tag into tag array
 			tags[x] = str:sub(start, stop)
 			--get rid of processed portion
-			str = str:gsub(lib.escape_lua_pattern(str:sub( 0, stop)),"")
+			str = str:gsub(lib.escape_lua_pattern(str:sub( 0, stop)),"", 1)
 		else --no more matches
 			if x == 1 then --account for lines that start with text before first override tag
 				x = x + 1
 			end
 			text[x-1] = str	--put remaining text into array
 			--get rid of processed portion
-			str = str:gsub(lib.escape_lua_pattern(str),"")
+			str = str:gsub(lib.escape_lua_pattern(str),"", 1)
 		end
 
 		x = x + 1
@@ -1088,7 +1088,7 @@ function filter_t_tags(tag_str)
 			end
 
 			--delete the string from tag_string
-			tag_str = tag_str:gsub(lib.escape_lua_pattern(tag_str:sub(t_start,t_end)),"")
+			tag_str = tag_str:gsub(lib.escape_lua_pattern(tag_str:sub(t_start,t_end)),"", 1)
 		end
 
 		--find next match


### PR DESCRIPTION
It's reasonable that lines might contain identical pairs of "tag-text groups": 
`{\an5\bord0\shad0\fs50\pos(393,295)\c&H272727&\fax-0.1}t{\fax0.1}e{\fax-0.1}s{\fax0.1}t {\fax-0.1}t{\fax0.1}e{\fax-0.1}s{\fax0.1}t`
Running `lib.split_at_override_tags` on this would result in the last three groups being deleted by the gsub call as they exactly match the earlier occurence. After running `Change Alignment` to \an5 for the line above:
`{\an5\bord0\shad0\fs50\pos(393.0000005,295)\c&H272727&\fax-0.1}t{\fax0.1}e{\fax-0.1}s{\fax0.1}t {\fax-0.1}t`

A similar bug happens in `lib.filter_t_tags`, concerning `\t(...)` groups.